### PR TITLE
Ignore missing file in include_once

### DIFF
--- a/src/lapistano/ProxyObject/Generator.php
+++ b/src/lapistano/ProxyObject/Generator.php
@@ -580,7 +580,7 @@ class Generator
      */
     protected static function createTemplateObject($file)
     {
-        include_once('Text/Template.php');
+        @include_once('Text/Template.php');
 
         return new \Text_Template($file);
     }


### PR DESCRIPTION
This uses the evil ``@`` operator to ignore if ``Text/Template.php`` is missing.

I'm doing it this way since ``phpunit/php-text-template`` is switching to using
composers autoloader with its latest 1.2.1 release.

Keeping the ``include_once`` line but letting it fail makes this work with both
1.2.0 and 1.2.1 of the lib.

This fixes running unit-tests in graviton after a ``composer update``.