### PR TITLE
README: SVG badge, Markdown heading fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-===========
-ProxyObject
-===========
+# ProxyObject
+
 Initiated by Thomas Weinert back in 2008 I picked up his work and completed, extended, and tested it.
 The outcome is this little library making it much easier to generate a proxy of your system under test (SUT).
 Another thought on this library was, that it should be very easy to use if you know the way to mock classes and methods
 in PHPUnit. Proxy-object has almost the same API, but does not change the behavior of the proxied class/method.
 The only purpose is to expose hidden (protected & private) methods and members. 
 
-Current travis status: [![Build Status](https://secure.travis-ci.org/lapistano/proxy-object.png?branch=master)](http://travis-ci.org/lapistano/proxy-object)
+Current travis status: [![Build Status](https://secure.travis-ci.org/lapistano/proxy-object.svg?branch=master)](http://travis-ci.org/lapistano/proxy-object)
 
 Installation
 ============


### PR DESCRIPTION
This PR changes the build badges to SVG for sharper readability ✨

Also fixes this mis-rendering of the heading in the README:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/211/33483957-983a5522-d6a0-11e7-89e7-d1b02153ef62.png">
